### PR TITLE
Adds "Redirect Twitter Share to Bluesky" add-on

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ Always use an app password, never your main password!
  - [Skeet](https://skeet.labnotes.org/) - find your Twitter or Mastodon mutuals on Bluesky
  - [Skeeter](https://skeeter.streamlit.app/) - Twitter/Mastodon to Bluesky User Search
  - [Sky Follower Bridge](https://chrome.google.com/webstore/detail/sky-follower-bridge/behhbpbpmailcnfbjagknjngnfdojpko) - Chrome add-on to find your Twitter follows and followers on Bluesky
+ - [Redirect Twitter Share to Bluesky](https://share.notx.blue/) - Chrome/Firefox add-on to redirect current Twitter/X share buttons to Bluesky
 
 ## Other tools
  - [bannerizer](https://bannerizer.glitch.me/) - easily crop or resize an image to fit Bluesky's banner size requirements


### PR DESCRIPTION
- Project URL: https://share.notx.blue/
- Chrome Webstore: https://chromewebstore.google.com/detail/redirect-twitter-share-to/llobhiaihifghfpkflpmnocdhimpkobf
- Firefox Add-ons: https://addons.mozilla.org/en-US/firefox/addon/share-notx-blue/