### PR TITLE
Change Kite to repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ Always use an app password, never your main password!
 ## Alternative Clients
  - [deck.blue](https://deck.blue/) - alternative web client with column view
  - [Graysky](https://graysky.app/) - alternative mobile client for both Android and iOS
- - [Kite](https://kite.black) - alternative web client
+ - [Kite](https://github.com/callmearta/kite) - alternative web client
  - [Langit](https://langit.pages.dev/) - alternative mobile web client
  - [Nootti](https://nootti.com) - alternative native iOS/iPad cross-posting client for Bluesky, Mastodon and Nostr
  - [Sky.app](https://github.com/jcsalterego/Sky.app) - alternative MacOS client


### PR DESCRIPTION
Due to insufficient funds, the Kite project has let the kite[.]black Domain Name expire. It appears that someone else has registered it after it expired, so to prevent anyone from potentially being redirected to a malicious service, linking to the project's repository would be best.

See here: https://github.com/callmearta/kite/issues/15