### PR TITLE
Add new client: Croissant

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,5 +57,6 @@ Know of another tool? Either submit it here as a pull request or simply tell me 
  - [Sky.app](https://github.com/jcsalterego/Sky.app) - alternative MacOS client
  - [SkyFeed](https://skyfeed.app) - alternative web client with a powerful custom feed builder
  - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - alternative web client
+ - [Croissant](https://croissantapp.com/) - alternative client to create posts
 
 

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ Know of another tool? Either submit it here as a pull request or simply tell me 
  - [SkyPicker](https://skypicker.site/) - Do raffles on Bluesky
 
 ## Alternative Clients
+ - [Croissant](https://croissantapp.com/) - alternative native iOS cross-posting client for Bluesky, Mastodon and Threads
  - [deck.blue](https://deck.blue/) - alternative web client with column view
  - [Graysky](https://graysky.app/) - alternative mobile client for both Android and iOS
  - [Kite](https://github.com/callmearta/kite) - alternative web client
@@ -57,6 +58,5 @@ Know of another tool? Either submit it here as a pull request or simply tell me 
  - [Sky.app](https://github.com/jcsalterego/Sky.app) - alternative MacOS client
  - [SkyFeed](https://skyfeed.app) - alternative web client with a powerful custom feed builder
  - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - alternative web client
- - [Croissant](https://croissantapp.com/) - alternative native iOS cross-posting client for Bluesky, Mastodon and Threads
 
 

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,6 @@ Know of another tool? Either submit it here as a pull request or simply tell me 
  - [Sky.app](https://github.com/jcsalterego/Sky.app) - alternative MacOS client
  - [SkyFeed](https://skyfeed.app) - alternative web client with a powerful custom feed builder
  - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - alternative web client
- - [Croissant](https://croissantapp.com/) - alternative client to create posts
+ - [Croissant](https://croissantapp.com/) - alternative native iOS cross-posting client for Bluesky, Mastodon and Threads
 
 


### PR DESCRIPTION
Croissant is an iOS app that allows you to post on Bluesky (as well as Threads and Mastodon). Helpful for people who cross-post regularly. 