### PR TITLE
Add Byesky

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Always use an app password, never your main password!
  - [Blueviewer](https://blueviewer.pages.dev/) - Bluesky thread viewer
  - [Bluniversal Comments](https://github.com/joneslloyd/bluniversal-comments) – Start a conversation next to any web page using your Bluesky account
  - [BskyThreadReader](https://bskythreadreader.glitch.me/) - Look at and share any Bluesky Thread without logging in.
+ - [Byesky](https://byesky.pirhoo.com/) - Clean-up followings, non-mutuals or simply delete all your subscriptions.
  - [cleanfollow-bsky](https://cleanfollow-bsky.pages.dev/) - tool to unfollow inactive or blocked accounts
  - [ClearSky Search Tool](https://clearsky.app/) - see who is blocking you, who a user is blocking, the total amount of Bluesky users, or look up a DID.
  - [did:plc Tracker](https://plc-handle-tracker.kpherox.dev/) - did:plc & atproto handle tracker

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Always use an app password, never your main password!
  - [Blueviewer](https://blueviewer.pages.dev/) - Bluesky thread viewer
  - [Bluniversal Comments](https://github.com/joneslloyd/bluniversal-comments) – Start a conversation next to any web page using your Bluesky account
  - [BskyThreadReader](https://bskythreadreader.glitch.me/) - Look at and share any Bluesky Thread without logging in.
- - [Byesky](https://byesky.pirhoo.com/) - Clean-up followings, non-mutuals or simply delete all your subscriptions.
+ - [Byesky](https://byesky.pirhoo.com/) - Clean-up followings, non-mutuals or simply delete all your subscriptions with ease.
  - [cleanfollow-bsky](https://cleanfollow-bsky.pages.dev/) - tool to unfollow inactive or blocked accounts
  - [ClearSky Search Tool](https://clearsky.app/) - see who is blocking you, who a user is blocking, the total amount of Bluesky users, or look up a DID.
  - [did:plc Tracker](https://plc-handle-tracker.kpherox.dev/) - did:plc & atproto handle tracker

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Always use an app password, never your main password!
  - [Blueviewer](https://blueviewer.pages.dev/) - Bluesky thread viewer
  - [Bluniversal Comments](https://github.com/joneslloyd/bluniversal-comments) – Start a conversation next to any web page using your Bluesky account
  - [BskyThreadReader](https://bskythreadreader.glitch.me/) - Look at and share any Bluesky Thread without logging in.
- - [Byesky](https://byesky.pirhoo.com/) - Clean-up followings, non-mutuals or simply delete all your subscriptions with ease.
+ - [Byesky](https://byesky.pirhoo.com/) - Clean-up followings, non-mutuals or simply delete all your subscriptions with ease
  - [cleanfollow-bsky](https://cleanfollow-bsky.pages.dev/) - tool to unfollow inactive or blocked accounts
  - [ClearSky Search Tool](https://clearsky.app/) - see who is blocking you, who a user is blocking, the total amount of Bluesky users, or look up a DID.
  - [did:plc Tracker](https://plc-handle-tracker.kpherox.dev/) - did:plc & atproto handle tracker


### PR DESCRIPTION
This PR adds the Byesky tool.

Byesky helps you manage your Bluesky subscriptions by cleaning up non-mutual follows, saying goodbye to all your subscriptions, identifying your true friends and locking users you want to continue following.