### PR TITLE
Change Sky Follower Bridge URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Always use an app password, never your main password!
  - [Follow the Sky](https://gggdomi.github.io/follow-the-sky/) - Find again in Bluesky people you follow on Twitter
  - [Skeet](https://skeet.labnotes.org/) - find your Twitter or Mastodon mutuals on Bluesky
  - [Skeeter](https://skeeter.streamlit.app/) - Twitter/Mastodon to Bluesky User Search
- - [Sky Follower Bridge](https://chrome.google.com/webstore/detail/sky-follower-bridge/behhbpbpmailcnfbjagknjngnfdojpko) - Chrome add-on to find your Twitter follows and followers on Bluesky
+ - [Sky Follower Bridge](https://www.sky-follower-bridge.dev) - Chrome add-on to find your Twitter follows and followers on Bluesky
  - [Redirect Twitter Share to Bluesky](https://share.notx.blue/) - Chrome/Firefox add-on to redirect current Twitter/X share buttons to Bluesky
 
 ## Post Analytics


### PR DESCRIPTION
I have changed the URL of the Sky Follower Bridge to the one on the official website.

https://www.sky-follower-bridge.dev
![CleanShot 2024-12-26 at 15 14 57@2x](https://github.com/user-attachments/assets/1bf9ae05-8ad2-4bc4-80dd-d1c40a8d55f0)
