### PR TITLE
feat(docs): Wamellow Discord Bot

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ Always use an app password, never your main password!
  - [PostPocket](https://apps.apple.com/au/app/postpocket-save-read-later/id6670723615) - iOS app to bookmark posts
  - [Profile Cleaner](https://bsky.jazco.dev/cleanup) - clean up old posts, likes, and reposts from your Bluesky account
  - [SkySweeper](https://skysweeper.p8.lu/) - automatically delete old posts
+ - [Wamellow Discord Bot](https://wamellow.com/docs/notifications) - Get Bluesky posts into Discord, as they happen, with filters and pings
  
 
 ## Other tools


### PR DESCRIPTION
Adds the Wamellow Discord Bot as an auto-poster for Bluesky -> Discord

>https://www.reddit.com/r/wamellow/comments/1hnbwsr/how_to_get_bluesky_post_into_discord/
>https://wamellow.com/docs/notifications

![A message of a Bluesky post in a Discord channel sent by Wamellow.com](https://github.com/user-attachments/assets/9aeb6be6-3f3e-489e-a081-f6d10ae5b9f1)